### PR TITLE
Fixed "contant" typo in about.md,introduction.md files

### DIFF
--- a/concepts/stringers/about.md
+++ b/concepts/stringers/about.md
@@ -40,7 +40,7 @@ Hence `fmt` functions will print `Distance` values using Go's "default format":
 mileUnit := Mile
 fmt.Sprint(mileUnit)
 // => 1
-// The result is '1' because that is the underlying value of the 'Mile' contant (see contant declarations above) 
+// The result is '1' because that is the underlying value of the 'Mile' constant (see constant declarations above) 
 
 dist := Distance{number: 790.7, unit: Kilometer}
 fmt.Sprint(dist)

--- a/concepts/stringers/introduction.md
+++ b/concepts/stringers/introduction.md
@@ -40,7 +40,7 @@ Hence `fmt` functions will print `Distance` values using Go's "default format":
 mileUnit := Mile
 fmt.Sprint(mileUnit)
 // => 1
-// The result is '1' because that is the underlying value of the 'Mile' contant (see contant declarations above) 
+// The result is '1' because that is the underlying value of the 'Mile' constant (see constant declarations above) 
 
 dist := Distance{number: 790.7, unit: Kilometer}
 fmt.Sprint(dist)

--- a/exercises/concept/meteorology/.docs/introduction.md
+++ b/exercises/concept/meteorology/.docs/introduction.md
@@ -40,7 +40,7 @@ Hence `fmt` functions will print `Distance` values using Go's "default format":
 mileUnit := Mile
 fmt.Sprint(mileUnit)
 // => 1
-// The result is '1' because that is the underlying value of the 'Mile' contant (see contant declarations above) 
+// The result is '1' because that is the underlying value of the 'Mile' constant (see constant declarations above) 
 
 dist := Distance{number: 790.7, unit: Kilometer}
 fmt.Sprint(dist)


### PR DESCRIPTION

Fixed typo "contant" to "constant" in:

concepts/stringers/about.md
concepts/stringers/introduction.md
exercises/concept/meteorology/.docs/introduction.md